### PR TITLE
fix docstring in build_classifier.py

### DIFF
--- a/saliency_metrics/models/build_classifier.py
+++ b/saliency_metrics/models/build_classifier.py
@@ -55,8 +55,8 @@ def build_classifier(cfg: Dict, default_args: Optional[Dict] = None) -> nn.Modul
     ``scope`` can be one of ``timm``, ``torchvision``, or ``custom``. When building a custom-defined classifier, the
     model should be already registered under ``saliency_metrics.models.CUSTOM_CLASSIFIERS`` registry. When building a
     classifier from ``torchvision`` or ``timm``, the ``model_name`` should be the name of corresponding builder
-    function, e.g., ``resnet18``. I.e., ``cfg = dict(type="torchvision.resnet18,)`` is equivalent to call
-    ``torchvision.models.resnet18``.
+    function, e.g., ``resnet18``. I.e., ``build_classifier(cfg=dict(type="torchvision.resnet18"))`` is equivalent to
+    call ``torchvision.models.resnet18``.
 
     .. _timm: https://rwightman.github.io/pytorch-image-models/
 


### PR DESCRIPTION
## Short Description

## Long Description
Fix docstring in `saliency_metrics/models/build_classifier.py`.

## Checklist

- [x] Code linting are passed. (Please run `pre-commit run --all-files`).
- [x] Mypy checks are passed. (Please run `mypy saliency_metrics`).
- [x] Unit tests are added for new code.
- [x] Documentation is added for the new code.
- [x] Unit tests are passed. (Please run `sh tests/run_tests.sh`).
- [x] Docs are successfully built. (Please run `cd docs/ && make html` and host the webpage locally).
